### PR TITLE
MyBinder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN conda config --system --add channels http://ssb.stsci.edu/astroconda
 
 # Install WFIRST Simulation Tools dependencies for python2 and python3
 # from conda:
-ENV EXTRA_PACKAGES astropy=2.x pyfftw pysynphot photutils future pyyaml pandas
+ENV EXTRA_PACKAGES astropy=2.0.6 pyfftw pysynphot photutils future pyyaml pandas
 RUN conda install --quiet --yes $EXTRA_PACKAGES && \
     conda clean -tipsy
 


### PR DESCRIPTION
This update will enable MyBinder to build wfirst-tools.
To test a Binder build from my forked repo, please use the link below:
https://mybinder.org/v2/gh/robelgeda/wfirst-tools.git/master


In this PR:
- `ftp` to `http` for synphot links
- astropy 2.0 for Pandeia