### PR TITLE
Pandeia v1.4.2 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot5.tar.gz | tar xvz
 ENV PYSYN_CDBS /opt/grp/hst/cdbs
 
 # Extract Pandeia reference data
-RUN wget -qO- https://stsci.box.com/shared/static/u2ithjsryhqnwzg3o3o2wfdink0q3z25.gz | tar -xvz
-ENV pandeia_refdata /opt/pandeia_data-1.4.1_wfirst
+RUN wget -qO- https://stsci.box.com/shared/static/0ijsmzs3ed7vwa7hk2dt372grxle8on7.gz | tar -xvz
+ENV pandeia_refdata /opt/pandeia_data-1.4.2_wfirst
 
 # Extract WebbPSF reference data
 # (note: version number env vars are declared close to where they are used

--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ Note that the `==1.4` on the package name explicitly requests version 1.4, which
 Pandeia also depends on a collection of reference data to define the characteristics of the WFIRST instruments. Download it (54 MB) as follows and extract:
 
 ```
-(wfirst-tools) $ curl -OL https://stsci.box.com/shared/static/u2ithjsryhqnwzg3o3o2wfdink0q3z25.gz
-(wfirst-tools) $ tar xvzf ./u2ithjsryhqnwzg3o3o2wfdink0q3z25.gz
+(wfirst-tools) $ curl -OL https://stsci.box.com/shared/static/0ijsmzs3ed7vwa7hk2dt372grxle8on7.gz
+(wfirst-tools) $ tar xvzf ./0ijsmzs3ed7vwa7hk2dt372grxle8on7.gz
 ```
 
-This creates a folder called `pandeia_data-1.4.1_wfirst` in the current directory.
+This creates a folder called `pandeia_data-1.4.2_wfirst` in the current directory.
 
 ## Running the simulation tools locally
 

--- a/notebooks/Pandeia-WFIRST.ipynb
+++ b/notebooks/Pandeia-WFIRST.ipynb
@@ -364,12 +364,12 @@
     "For the WFIRST Imager:\n",
     "\n",
     "- Filters\n",
-    "   - r062 (R-band 0.62 microns)\n",
-    "   - z087 (Z-band 0.87 microns) - the default\n",
-    "   - y106 (Y-band 1.06 microns)\n",
-    "   - j129 (J-band 1.29 microns)\n",
-    "   - w146 (wide-band 1.46 microns)\n",
-    "   - h158 (H-band 1.58 microns)\n",
+    "   - f062 (R-band 0.62 microns)\n",
+    "   - f087 (Z-band 0.87 microns) - the default\n",
+    "   - f106 (Y-band 1.06 microns)\n",
+    "   - f129 (J-band 1.29 microns)\n",
+    "   - f146 (wide-band 1.46 microns)\n",
+    "   - f158 (H-band 1.58 microns)\n",
     "   - f184 (f-band 1.84 microns)\n",
     "   \n",
     "There are no valid dispersive elements, and only one aperture: 'any'.\n",
@@ -411,7 +411,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calc['configuration']['instrument']['filter'] = \"z087\"\n",
+    "calc['configuration']['instrument']['filter'] = \"f087\"\n",
     "calc['configuration']['instrument']['aperture'] = \"any\"\n",
     "calc['configuration']['instrument']['disperser'] = None\n",
     "calc['configuration']['detector']['ngroup'] = 6 # groups per integration\n",
@@ -427,7 +427,7 @@
    "source": [
     "### WFIRST Grism\n",
     "\n",
-    "For the WFIRST Grism, there is much less to configure. There is one grism bandpass filter (g150), and only one disperser: the GRS Grism (grsgrism). The readmode and subarray options are the same as the WFIRST Imager.\n",
+    "For the WFIRST Grism, there is much less to configure. There is no grism bandpass filter, and two dispersers: the GRS Grism (grsgrism), and the prism (prism). The readmode and subarray options are the same as the WFIRST Imager.\n",
     "\n",
     "To approximate the current design for the High Latitude Spectroscopic Survey, we recommend using subarray '1024x1024', readmode 'medium8', and Ngroups = 13"
    ]
@@ -438,7 +438,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calc['configuration']['instrument']['filter'] = \"g150\"\n",
+    "calc['configuration']['instrument']['filter'] = None\n",
     "calc['configuration']['instrument']['aperture'] = \"grism\"\n",
     "calc['configuration']['instrument']['disperser'] = \"grsgrism\"\n",
     "calc['configuration']['detector']['ngroup'] = 13 # groups per integration\n",
@@ -715,7 +715,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -729,7 +729,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/Pandeia-WFIRST.ipynb
+++ b/notebooks/Pandeia-WFIRST.ipynb
@@ -160,7 +160,7 @@
    "source": [
     "The type of flux normalization can be changed. Run the cell below to normalize to a bandpass\n",
     "- Valid bandpasses are:\n",
-    "   - bessel,J (or H or K)\n",
+    "   - bessell,J (or H or K)\n",
     "   - cousins,I\n",
     "   - johnson,V (or I, J, K)\n",
     "   - sdss,u (or g, r, i, or z)\n",
@@ -224,12 +224,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also change the shape of the source. Valid options are 'point', 'gaussian2d', 'sersic', and 'flat'. \n",
+    "We can also change the shape of the source. Valid options are 'point', 'gaussian2d', 'sersic', 'sersic_scale', 'power', and 'flat'. \n",
     "\n",
-    "'point' (the default) is a point source, represented as a simple impulse function to convolve with the PSF.\n",
-    "'flat' is an ellipse step function, with a uniform distribution out to the bounding curve.\n",
-    "'gaussian2d' is a two-dimensional gaussian function, where major and minor are now the 1-sigma boundaries.\n",
-    "'sersic' is NOT the typical sersic formulation from Graham & Driver (1992); it is an e-folding version, defined as $e^{-r(\\frac{1}{index})}$. index=4 is the standard De Vaucoulers profile, index 0.5 is similar to a gaussian, and index=1 is an exponential profile.\n",
+    "- 'point' (the default) is a point source, represented as a simple impulse function to convolve with the PSF.\n",
+    "- 'flat' is an ellipse step function, with a uniform distribution out to the bounding curve.\n",
+    "- 'gaussian2d' is a two-dimensional gaussian function, where major and minor are now the 1-sigma boundaries.\n",
+    "- 'sersic' is the sersic formulation from Graham & Driver (1992) where the semimajor and semiminor axes are for the effective radius.\n",
+    "- 'sersic_scale' is NOT the typical sersic formulation from Graham & Driver (1992); it is an e-folding version, defined as $e^{-r(\\frac{1}{index})}$. index=4 is the standard De Vaucoulers profile, index 0.5 is similar to a gaussian, and index=1 is an exponential profile.\n",
+    "- 'power' is a circular power-law profile, whose only options are r_core (radius of a flat central code, in arcseconds) and 'power_index', the power of the power law. The only valid normalization is surf_center.\n",
     "\n",
     "If you change the shape to gaussian2d, flat, or sersic, you have additional parameters to fill. In particular, there are options to change how you set the source brightness:\n",
     " - 'integ_infinity' Integrates the flux of the entire profile\n",
@@ -287,6 +289,33 @@
     "calc['scene'][0]['shape']['minor'] = 0.2 # arcsec\n",
     "calc['scene'][0]['shape']['sersic_index'] = 1.0\n",
     "calc['scene'][0]['shape']['norm_method'] = 'surf_scale'\n",
+    "calc['scene'][0]['shape']['surf_area_units'] = 'sr'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calc['scene'][0]['shape']['geometry'] = 'sersic_scale'\n",
+    "calc['scene'][0]['shape']['major'] = 0.5 # arcsec\n",
+    "calc['scene'][0]['shape']['minor'] = 0.2 # arcsec\n",
+    "calc['scene'][0]['shape']['sersic_index'] = 1.0\n",
+    "calc['scene'][0]['shape']['norm_method'] = 'surf_scale'\n",
+    "calc['scene'][0]['shape']['surf_area_units'] = 'sr'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calc['scene'][0]['shape']['geometry'] = 'power'\n",
+    "calc['scene'][0]['shape']['r_core'] = 0.1 # arcsec\n",
+    "calc['scene'][0]['shape']['power_index'] = 1.0\n",
+    "calc['scene'][0]['shape']['norm_method'] = 'surf_center'\n",
     "calc['scene'][0]['shape']['surf_area_units'] = 'sr'"
    ]
   },
@@ -427,7 +456,13 @@
    "source": [
     "### WFIRST Grism\n",
     "\n",
-    "For the WFIRST Grism, there is much less to configure. There is no grism bandpass filter, and two dispersers: the GRS Grism (grsgrism), and the prism (prism). The readmode and subarray options are the same as the WFIRST Imager.\n",
+    "For the WFIRST Grism, there is much less to configure. There are no filters, and two dispersers: The grism and the prism.\n",
+    "\n",
+    "* Dispersers:\n",
+    "  * g150 (default)\n",
+    "  * p120\n",
+    "  \n",
+    "The readout pattern and subarray options are the same as the WFIRST Imager imaging mode.\n",
     "\n",
     "To approximate the current design for the High Latitude Spectroscopic Survey, we recommend using subarray '1024x1024', readmode 'medium8', and Ngroups = 13"
    ]
@@ -440,7 +475,7 @@
    "source": [
     "calc['configuration']['instrument']['filter'] = None\n",
     "calc['configuration']['instrument']['aperture'] = \"grism\"\n",
-    "calc['configuration']['instrument']['disperser'] = \"grsgrism\"\n",
+    "calc['configuration']['instrument']['disperser'] = \"prism\"\n",
     "calc['configuration']['detector']['ngroup'] = 13 # groups per integration\n",
     "calc['configuration']['detector']['nint'] = 1 # integrations per exposure\n",
     "calc['configuration']['detector']['nexp'] = 1 # exposures\n",
@@ -527,9 +562,9 @@
     "### WFIRST IFU Channel\n",
     "\n",
     "For WFIRST IFU, there are three different observation strategies:\n",
-    "    - 'ifuapphot': IFU Aperture Photometry. An IFU without dithers, which will be displayed in 2D as a slice of the resulting image cube (at the reference wavelength)\n",
-    "    - 'ifunodinscene': IFU Nod (in-scene) - the default. The same as the above, but with an dither smaller (generally <5 arcsec) than the FOV size.\n",
-    "    - 'ifunodoffscene': IFU Nod (off-scene). The same as the above, but the dither is larger (generally >10 arcsec) than the FOV size.\n",
+    " - 'ifuapphot': IFU Aperture Photometry. An IFU without dithers, which will be displayed in 2D as a slice of the resulting image cube (at the reference wavelength)\n",
+    " - 'ifunodinscene': IFU Nod (in-scene) - the default. The same as the above, but with an dither smaller (generally <5 arcsec) than the FOV size.\n",
+    " - 'ifunodoffscene': IFU Nod (off-scene). The same as the above, but the dither is larger (generally >10 arcsec) than the FOV size.\n",
     "    \n",
     "Note that Pandeia doesn't currently shift when it adds the dithers; this is a known limitation."
    ]
@@ -605,8 +640,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for x in results['scalar'].keys():\n",
-    "   print(\"{0:}:\\t{1:}\".format(x,results['scalar'][x]))"
+    "# print the scalar products with what (I think) are the correct units.\n",
+    "print(\"------------------\\n     RESULTS    \\n------------------\")\n",
+    "for x in sorted(result[\"scalar\"]):\n",
+    "    basename = \"{:20}: {}\"\n",
+    "    if \"time\" in x:\n",
+    "        basename += \" sec\"\n",
+    "    elif \"size\" in x or \"offset\" in x:\n",
+    "        basename += \" arcsec\"\n",
+    "    elif \"area\" in x:  # checking this before background means the\n",
+    "                       # background_area will be given the correct units.\n",
+    "        basename += \" pixel^2\"\n",
+    "    elif \"wavelength\" in x:\n",
+    "        basename += \" microns\"\n",
+    "    elif \"background\" in x or \"extracted\" in x:\n",
+    "        basename += \" e-/sec\"\n",
+    "    else:\n",
+    "        pass\n",
+    "    print(basename.format(x,result[\"scalar\"][x]))\n",
+    "\n",
+    "# also print out the value and location of the best SNR\n",
+    "bestsn = np.argmax(result[\"1d\"][\"sn\"][1])\n",
+    "print(\"------------------\")\n",
+    "print(\"Highest SNR: {:.3f} at {:.3f} microns\".format(result[\"1d\"][\"sn\"][1][bestsn], result[\"1d\"][\"sn\"][0][bestsn]))\n",
+    "if len(result['warnings']) > 0:\n",
+    "    print(\"----------------\\n  WARNINGS  \\n----------------\")\n",
+    "    for x in result['warnings']:\n",
+    "        print(\"{:20}: {}\".format(x,result['warnings'][x]))"
    ]
   },
   {

--- a/notebooks/Pandeia-WFIRST.ipynb
+++ b/notebooks/Pandeia-WFIRST.ipynb
@@ -405,9 +405,9 @@
     "\n",
     "The detector can be configured to give multiple exposures in multiple groups and integrations, and set the readmode. We are using the available JWST NIRCam configurations as stand-ins for the WFIRST detector, as the WFIRST WFI detectors are expected to be very similar to the NIRCam detectors. \n",
     "\n",
-    "For the WFIRST imager, there are a number of readmodes:\n",
+    "For the WFIRST imager, there are a number of readout patterns:\n",
     "\n",
-    "- Readmodes:\n",
+    "- Readout Patterns:\n",
     "   - 'rapid'\n",
     "   - 'shallow2'\n",
     "   - 'shallow4'\n",
@@ -475,7 +475,7 @@
    "source": [
     "calc['configuration']['instrument']['filter'] = None\n",
     "calc['configuration']['instrument']['aperture'] = \"grism\"\n",
-    "calc['configuration']['instrument']['disperser'] = \"prism\"\n",
+    "calc['configuration']['instrument']['disperser'] = \"g150\"\n",
     "calc['configuration']['detector']['ngroup'] = 13 # groups per integration\n",
     "calc['configuration']['detector']['nint'] = 1 # integrations per exposure\n",
     "calc['configuration']['detector']['nexp'] = 1 # exposures\n",
@@ -540,7 +540,7 @@
     "\n",
     "For the WFIRST grism, the only strategy available is 'specapphot' (Aperture Spectral Extraction) and again does not need to be set. \n",
     "\n",
-    "The rest of the options are quite similar to the imager options, with the addition of a reference wavelength at which you want the flux and SNR to be calculated for the numerical results. If it is set to None, Pandeia will choose the central wavelength for the Grism (1.62 microns)"
+    "The rest of the options are quite similar to the imager options, with the addition of a reference wavelength at which you want the flux and SNR to be calculated for the numerical results. If it is set to None, Pandeia will choose the central wavelength of the disperser."
    ]
   },
   {
@@ -642,7 +642,7 @@
    "source": [
     "# print the scalar products with what (I think) are the correct units.\n",
     "print(\"------------------\\n     RESULTS    \\n------------------\")\n",
-    "for x in sorted(result[\"scalar\"]):\n",
+    "for x in sorted(results[\"scalar\"]):\n",
     "    basename = \"{:20}: {}\"\n",
     "    if \"time\" in x:\n",
     "        basename += \" sec\"\n",
@@ -657,16 +657,16 @@
     "        basename += \" e-/sec\"\n",
     "    else:\n",
     "        pass\n",
-    "    print(basename.format(x,result[\"scalar\"][x]))\n",
+    "    print(basename.format(x,results[\"scalar\"][x]))\n",
     "\n",
     "# also print out the value and location of the best SNR\n",
-    "bestsn = np.argmax(result[\"1d\"][\"sn\"][1])\n",
+    "bestsn = np.argmax(results[\"1d\"][\"sn\"][1])\n",
     "print(\"------------------\")\n",
-    "print(\"Highest SNR: {:.3f} at {:.3f} microns\".format(result[\"1d\"][\"sn\"][1][bestsn], result[\"1d\"][\"sn\"][0][bestsn]))\n",
-    "if len(result['warnings']) > 0:\n",
+    "print(\"Highest SNR: {:.3f} at {:.3f} microns\".format(results[\"1d\"][\"sn\"][1][bestsn], results[\"1d\"][\"sn\"][0][bestsn]))\n",
+    "if len(results['warnings']) > 0:\n",
     "    print(\"----------------\\n  WARNINGS  \\n----------------\")\n",
-    "    for x in result['warnings']:\n",
-    "        print(\"{:20}: {}\".format(x,result['warnings'][x]))"
+    "    for x in results['warnings']:\n",
+    "        print(\"{:20}: {}\".format(x,results['warnings'][x]))"
    ]
   },
   {

--- a/notebooks/Pandeia-WFIRST_GUI.ipynb
+++ b/notebooks/Pandeia-WFIRST_GUI.ipynb
@@ -10,36 +10,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4028b35e92ea46c399be53fb5ac906ba",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(HTML(value=\"<b>If no advanced settings are changed,</b> a centered point source with no redshif…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/riedel/anacondac/envs/pan9.2_c_3.6/lib/python3.6/site-packages/pandeia.engine-1.4-py3.6.egg/pandeia/engine/etc3D.py:1285: FutureWarning: The 'readmode' keyword will be corrected to 'readout_pattern' in v1.5.\n",
-      "  warn(\"The 'readmode' keyword will be corrected to 'readout_pattern' in v1.5.\", category=FutureWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from pandeia.engine import nb_utils2\n",
+    "import nb_utils2\n",
     "gui = nb_utils2.WFIRST_gui()\n",
     "%matplotlib inline\n",
     "gui.display"

--- a/notebooks/Pandeia-WFIRST_GUI.ipynb
+++ b/notebooks/Pandeia-WFIRST_GUI.ipynb
@@ -10,11 +10,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4028b35e92ea46c399be53fb5ac906ba",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HTML(value=\"<b>If no advanced settings are changed,</b> a centered point source with no redshif…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/riedel/anacondac/envs/pan9.2_c_3.6/lib/python3.6/site-packages/pandeia.engine-1.4-py3.6.egg/pandeia/engine/etc3D.py:1285: FutureWarning: The 'readmode' keyword will be corrected to 'readout_pattern' in v1.5.\n",
+      "  warn(\"The 'readmode' keyword will be corrected to 'readout_pattern' in v1.5.\", category=FutureWarning)\n"
+     ]
+    }
+   ],
    "source": [
     "from pandeia.engine import nb_utils2\n",
     "gui = nb_utils2.WFIRST_gui()\n",
@@ -32,21 +55,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:pandeia_9]",
+   "display_name": "Python [conda env:pan9.2_c_3.6]",
    "language": "python",
-   "name": "conda-env-pandeia_9-py"
+   "name": "conda-env-pan9.2_c_3.6-py"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/nb_utils2.py
+++ b/notebooks/nb_utils2.py
@@ -8,8 +8,6 @@ import os
 import json
 
 import matplotlib
-from matplotlib import style
-style.use('ggplot')
 matplotlib.use('nbagg')
 import matplotlib.pyplot as plt
 
@@ -44,7 +42,7 @@ class Instrument():
     If a mode is set, the class object will expose available apertures and
      strategies for that mode.
     If an aperture is set as well, the class object will expose the valid
-     filters, dispersers, readmodes, and subarrays,
+     filters, dispersers, readout patterns, and subarrays,
 
     The remainder of the instrument configuration is available as self.config
 
@@ -249,7 +247,6 @@ class SourceObj(object):
         self.norm = widgets.Dropdown(description="Normalize at: ", options=['infinity', 'scale radius', 'center'], style=style)
         self.norm_flat = widgets.Dropdown(description="Normalize at: ", options=['infinity', 'center'], style=style)
         self.prof_box.children = [self.major, self.minor, self.r_core, self.pos_a, self.norm, self.sersic, self.power]
-        self.prof_box.children = [self.major, self.minor, self.pos_a, self.norm, self.sersic]
         self.geom_box.children = [self.source_box, self.prof_box]
 
         # Position
@@ -279,99 +276,57 @@ class SourceObj(object):
 
     def on_sed_change(self, change):
         # For each possible setting of sed, flip the individual dropdown box sets on and off accordingly.
-        if self.sed_select.value == "flat":
-            self.bb_temp.layout.display = 'none'
-            self.phoenix.layout.display = 'none'
-            self.galaxies.layout.display = 'none'
-            self.star.layout.display = 'none'
-            self.pl_index.layout.display = 'none'
-        elif self.sed_select.value == "phoenix":
-            self.bb_temp.layout.display = 'none'
+        self.bb_temp.layout.display = 'none'
+        self.phoenix.layout.display = 'none'
+        self.galaxies.layout.display = 'none'
+        self.star.layout.display = 'none'
+        self.pl_index.layout.display = 'none'
+        if self.sed_select.value == "phoenix":
             self.phoenix.layout.display = "inline"
-            self.galaxies.layout.display = 'none'
-            self.star.layout.display = 'none'
-            self.pl_index.layout.display = 'none'
         elif self.sed_select.value == "blackbody":
             self.bb_temp.layout.display = "inline"
-            self.phoenix.layout.display = 'none'
-            self.galaxies.layout.display = 'none'
-            self.star.layout.display = 'none'
-            self.pl_index.layout.display = 'none'
         elif self.sed_select.value == "extragalactic":
-            self.bb_temp.layout.display = 'none'
-            self.phoenix.layout.display = 'none'
             self.galaxies.layout.display = "inline"
-            self.star.layout.display = 'none'
-            self.pl_index.layout.display = 'none'
         elif self.sed_select.value == "star":
-            self.bb_temp.layout.display = 'none'
-            self.phoenix.layout.display = 'none'
-            self.galaxies.layout.display = 'none'
             self.star.layout.display = "inline"
-            self.pl_index.layout.display = 'none'
         elif self.sed_select.value == "power-law":
-            self.bb_temp.layout.display = 'none'
-            self.phoenix.layout.display = 'none'
-            self.galaxies.layout.display = 'none'
-            self.star.layout.display = 'none'
-            self.pl_index.layout.display = 'inline'
+            self.pl_index.layout.display = "inline"
 
     def on_prof_change(self,change):
         # For each possible setting of source, flip the properties boxes on and off accordingly.
-        if self.src_select.value == "Point Source":
-            self.major.layout.display = 'none'
-            self.minor.layout.display = 'none'
-            self.pos_a.layout.display = 'none'
-            self.sersic.layout.display = 'none'
-            self.power.layout.display = 'none'
-            self.r_core.layout.display = 'none'
-            self.norm.layout.display = 'none'
-            self.norm_flat.layout.display = 'none'
-        elif self.src_select.value == "2D Gaussian":
+        self.major.layout.display = 'none'
+        self.minor.layout.display = 'none'
+        self.pos_a.layout.display = 'none'
+        self.sersic.layout.display = 'none'
+        self.power.layout.display = 'none'
+        self.r_core.layout.display = 'none'
+        self.norm.layout.display = 'none'
+        self.norm_flat.layout.display = 'none'
+        if self.src_select.value == "2D Gaussian":
             self.major.layout.display = 'inline'
             self.minor.layout.display = 'inline'
             self.pos_a.layout.display = 'inline'
-            self.sersic.layout.display = 'none'
-            self.power.layout.display = 'none'
-            self.r_core.layout.display = 'none'
             self.norm.layout.display = 'inline'
-            self.norm_flat.layout.display = 'none'
         elif self.src_select.value == "Flat":
             self.major.layout.display = 'inline'
             self.minor.layout.display = 'inline'
             self.pos_a.layout.display = 'inline'
-            self.sersic.layout.display = 'none'
-            self.power.layout.display = 'none'
-            self.r_core.layout.display = 'none'
-            self.norm.layout.display = 'none'
             self.norm_flat.layout.display = 'inline'
         elif self.src_select.value == "Sersic (Scale Radius)":
             self.major.layout.display = 'inline'
             self.minor.layout.display = 'inline'
             self.pos_a.layout.display = 'inline'
             self.sersic.layout.display = 'inline'
-            self.power.layout.display = 'none'
-            self.r_core.layout.display = 'none'
             self.norm.layout.display = 'inline'
-            self.norm_flat.layout.display = 'none'
         elif self.src_select.value == "Sersic (Effective Radius)":
             self.major.layout.display = 'inline'
             self.minor.layout.display = 'inline'
             self.pos_a.layout.display = 'inline'
             self.sersic.layout.display = 'inline'
-            self.power.layout.display = 'none'
-            self.r_core.layout.display = 'none'
             self.norm.layout.display = 'inline'
-            self.norm_flat.layout.display = 'none'
         elif self.src_select.value == "Power Law":
-            self.major.layout.display = 'none'
-            self.minor.layout.display = 'none'
-            self.pos_a.layout.display = 'none'
-            self.sersic.layout.display = 'none'
             self.power.layout.display = 'inline'
             self.r_core.layout.display = 'inline'
-            self.norm.layout.display = 'none'
-            self.norm_flat.layout.display = 'none'
 
 
 class InstObj(object):
@@ -498,11 +453,11 @@ class SpecApPhotObj(ImagingApPhotObj):
 
         self.target_box = widgets.HBox(padding='10px', width="100%")
         targ_lab = widgets.HTML(value="Extraction Target: ", margin='5px')
-        self.target_x = widgets.BoundedFloatText(description="X:", min=-37.5, max=37.5, value=0, width=30)
-        self.target_y = widgets.BoundedFloatText(description="Y:", min=-37.5, max=37.5, value=0, width=30)
+        self.target_x = widgets.BoundedFloatText(description="X:", min=-37.5, max=37.5, value=0, step=0.01, width=30)
+        self.target_y = widgets.BoundedFloatText(description="Y:", min=-37.5, max=37.5, value=0, step=0.01, width=30)
         self.target_box.children = [targ_lab, self.target_x, self.target_y]
 
-        self.reference_wavelength = widgets.BoundedFloatText(description="Wavelength of Interest", min=0.95, max=1.8, value=1.3, width=30, style=style)
+        self.reference_wavelength = widgets.BoundedFloatText(description="Wavelength of Interest", min=0.95, max=1.8, value=1.3, width=30, step=0.01, style=style)
 
         self.advanced = widgets.VBox(width="100%", background_color="#AAAAAA")
         self.aperture_box = widgets.HBox(padding='10px', width="100%")
@@ -533,7 +488,7 @@ class WFIRST_gui(object):
     def __init__(self):
         self.r = {}
         usernotes = widgets.HTML(value="<b>If no advanced settings are changed,</b> a centered point source with no "
-                                      "redshift will be computed using readmode 'medium8' and subarray '1024x1024', "
+                                      "redshift will be computed using readout pattern 'medium8' and subarray '1024x1024', "
                                        "with extraction aperture centered at 0,0 with a size of 0.1 arcsec, and a sky "
                                       "annulus from 0.2-0.3 arcsec."
                                        "<p>The readout patterns are currently inherited from JWST NIRCam. To best "
@@ -545,11 +500,11 @@ class WFIRST_gui(object):
                                        #"<li>WFIRST does not currently anticipate resetting the detector during an "
                                        #"exposure.  Thus Integrations should be set to 1.</li>"
                                        "<li><i>To approximate the current design for the High Latitude Imaging "
-                                       "Survey:</i> readmode 'medium8' with Ngroups = 6 </li>"
+                                       "Survey:</i> readout pattern 'medium8' with Ngroups = 6 </li>"
                                        "<li><i>To approximate the current design for the High Latitude Spectroscopic "
-                                       "Survey:</i> readmode 'medium8' with Ngroups = 13</li> "
+                                       "Survey:</i> readout pattern 'medium8' with Ngroups = 13</li> "
                                        "<li><i>To approximate the current design for the Exoplanet Microlensing "
-                                       "Survey:</i> readmode 'shallow2' with Ngroups = 4</li")
+                                       "Survey:</i> readout pattern 'shallow2' with Ngroups = 4</li")
 
 
         self.form = widgets.VBox(width="100%", background_color="#EEE")
@@ -630,20 +585,15 @@ class WFIRST_gui(object):
 
         self.json_output = widgets.Textarea(value='', description='A JSON-formatted copy of your inputs:')
 
-        tlab1 = widgets.HTML(value="<b>Extracted S/N: <b>", margin='5px')
-        self.esn = widgets.HTML(value="0.0", margin='5px')
-        tlab2 = widgets.HTML(value="       <b>Extracted Flux (e-/sec): </b>", margin='5px')
-        self.eflux = widgets.HTML(value="0.0", margin='5px')
-        tlab3 = widgets.HTML(value="       <b>Exposure Time (sec): <b>", margin='5px')
-        self.etime = widgets.HTML(value="0.0", margin='5px')
+        self.reportpane = widgets.HTML(value="<hr>", margin='5px')
 
         self.computing_notice = widgets.HTML(value="<i>Calculating... please wait.</i>", margin='5px')
         self.computing_notice.layout.display = 'none'
 
         self.tab_form = widgets.HBox(padding='10px', width="100%", pack='center')
-        self.tab_form.children = [tlab1, self.esn, tlab2, self.eflux, tlab3, self.etime]
+        self.tab_form.children = [self.reportpane]
 
-        self.result_form.children = [self.tab_form, self.plot2d_form, self.plot1d_form]
+        self.result_form.children = [self.plot2d_form, self.plot1d_form, self.tab_form]
 
         self.form.children = [
             usernotes,
@@ -678,13 +628,16 @@ class WFIRST_gui(object):
         im = ax1.imshow(self.r['2d'][plotname],cmap='coolwarm', extent=extent)
         ax1.set_xlabel('arcsec')
         ax1.set_ylabel('arcsec')
+        orient = "vertical"
+        if self.r['2d'][plotname].shape[0] != self.r['2d'][plotname].shape[1]:
+            orient = "horizontal"
         if plotname == "saturation":
             norm = matplotlib.colors.Normalize(vmin=0, vmax=2)
             im.set_norm(norm)
-            c = fig.colorbar(im, ax=ax1, orientation="horizontal", label=unitstring, ticks=[0, 1, 2])
+            c = fig.colorbar(im, ax=ax1, orientation=orient, label=unitstring, ticks=[0, 1, 2])
             c.ax.set_xticklabels(["None", "Partial", "Full"])
         else:
-            c = fig.colorbar(im, ax=ax1, orientation="horizontal", label=unitstring)
+            c = fig.colorbar(im, ax=ax1, orientation=orient, label=unitstring)
         plt.tight_layout()
         plt.show()
 
@@ -787,6 +740,7 @@ class WFIRST_gui(object):
         c['configuration']['detector']['readmode'] = self.mode_config[calc_mode].readmode.value
         c['configuration']['detector']['subarray'] = self.mode_config[calc_mode].subarray.value
         c['configuration']['instrument']['filter'] = self.mode_config[calc_mode].filt.value
+        c['configuration']['instrument']['disperser'] = self.mode_config[calc_mode].disp.value
 
         c['scene'] = []
 
@@ -855,9 +809,28 @@ class WFIRST_gui(object):
 
         self.r = perform_calculation(c, dict_report=True)
         self.calc_input = c
-        self.esn.value = "%.2f" % self.r['scalar']['sn']
-        self.eflux.value = "%.2f" % self.r['scalar']['extracted_flux']
-        self.etime.value = "%.2f" % self.r['scalar']['total_exposure_time']
+
+        resultpane = ["<hr><h3><center>RESULTS</center></h3><hr><table>"]
+        for x in sorted(self.r["scalar"]):
+            suffix = ''
+            if "time" in x:
+                suffix = "sec"
+            elif "size" in x or "offset" in x:
+                suffix = "arcsec"
+            elif "area" in x:  # checking this before background means the
+                               # background_area will be given the correct units.
+                suffix = "pixel^2"
+            elif "wavelength" in x:
+                suffix = "microns"
+            elif "background" in x or "extracted" in x:
+                suffix = "e-/sec"
+            else:
+                pass
+            resultpane.append("<tr><td><b>{}</b></td><td>{}</td><td>{}</td></tr>".format(x.replace('_', ' ').title(), self.r["scalar"][x], suffix))
+        resultpane.append('</table>')
+
+
+        self.reportpane.value = ''.join(resultpane)
 
         self.update_plots()
         # Now set the result form to be shown


### PR DESCRIPTION
The pandeia v1.4.2 update (https://github.com/spacetelescope/pandeia_data/pull/439) only involves a new datafile.

The notebook updates:
* Pandeia-WFIRST: Has all the new filter and disperser names, and some cleanup, and sections for using the new sersic and power law source profiles. Also has a new Results section printing out ALL the results.
* Pandeia-WFIRST_GUI: Fixed so that it reads the GUI out of the nbutils2.py file in this repo.
That GUI has been updated so that sersic_scale and power law profiles work correctly, as do changing dispersers (not noticed before we had two to choose from). Additional cosmetic updates: The distracting grid on the 2D plots is gone, a scale bar has been added to the plots, and there's a new Results pane.