### PR TITLE
Update for Pandeia v1.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ RUN wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot5.tar.gz | tar xvz
 ENV PYSYN_CDBS /opt/grp/hst/cdbs
 
 # Extract Pandeia reference data
-RUN wget -qO- https://stsci.box.com/shared/static/ve02bw7h6qzmxtu8rpxewkl3m5jduacq.gz | tar 
+RUN wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz | tar 
 -xvz
-ENV pandeia_refdata /opt/pandeia_data-1.5.1_wfirst
+ENV pandeia_refdata /opt/pandeia_data-1.5.2_roman
 
 # Extract WebbPSF reference data
 # (note: version number env vars are declared close to where they are used
@@ -38,7 +38,7 @@ WORKDIR $HOME
 
 # Prepare environment variables
 ENV PYHOME /opt/conda
-ENV PYTHON_VERSION 3.6
+ENV PYTHON_VERSION 3.7
 ENV PATH $HOME/bin:$PATH
 ENV LD_LIBRARY_PATH $HOME/lib:$LD_LIBRARY_PATH
 
@@ -47,16 +47,15 @@ RUN conda config --add channels conda-forge
 # Configure AstroConda
 RUN conda config --system --add channels http://ssb.stsci.edu/astroconda
 
-# Install WFIRST Simulation Tools dependencies for python2 and python3
-# from conda:
-ENV EXTRA_PACKAGES astropy pysynphot photutils future pyyaml pandas
+# Install WFIRST Simulation Tools dependencies for python3 from conda:
+ENV EXTRA_PACKAGES astropy synphot stsynphot photutils future pyyaml pandas
 RUN conda install --quiet --yes $EXTRA_PACKAGES && \
     conda clean -tipsy
 
 RUN pip install ipywidgets==7.0.0
 
 # Install Pandeia
-ENV PANDEIA_VERSION 1.5.1
+ENV PANDEIA_VERSION 1.5.2
 RUN pip install --no-cache-dir pandeia.engine==$PANDEIA_VERSION
 
 # Install WebbPSF

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN conda config --add channels conda-forge
 RUN conda config --system --add channels http://ssb.stsci.edu/astroconda
 
 # Install WFIRST Simulation Tools dependencies for python3 from conda:
-ENV EXTRA_PACKAGES astropy synphot stsynphot photutils future pyyaml pandas
+ENV EXTRA_PACKAGES astropy synphot stsynphot pysynphot photutils future pyyaml pandas
 RUN conda install --quiet --yes $EXTRA_PACKAGES && \
     conda clean -tipsy
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The [Getting Started](http://astroconda.readthedocs.io/en/latest/getting_started
 The Roman Simulation Tools suite includes the Pandeia engine, an exposure time and signal-to-noise calculator. To create a Python environment for Roman Simulation Tools, use the following command:
 
 ```
-$ conda create -n wfirst-tools --yes python=3.7 astropy \
+$ conda create -n wfirst-tools --yes python=3.7 astropy pysynphot \
                                     synphot stsynphot photutils \
                                     future pyyaml pandas \
                                     webbpsf==0.9 webbpsf-data==0.9

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# WFIRST Simulation Tools
+# Nancy Grace Roman Space Telescope Simulation Tools
 
-The WFIRST team at STScI has developed an exposure time calculator, a PSF model, and an image simulator for the science community to plan how they will use WFIRST. These tools are available separately as the Pandeia exposure time calculator engine, the WebbPSF point spread function modeling package, and the Space Telescope Image Product Simulator (STIPS).   Comprehensive setup documentation for local installation as well as tutorials for Pandeia and WebbPSF are provided here.  STIPS is available at https://github.com/spacetelescope/STScI-STIPS.  High level overviews of the functionality of the tools are available on [STScI's WFIRST website](http://www.stsci.edu/scientific-community/wide-field-infrared-survey-telescope/science-planning-toolbox).
+The Roman team at STScI has developed an exposure time calculator, a PSF model, and an image simulator for the science community to plan how they will use Roman. These tools are available separately as the Pandeia exposure time calculator engine, the WebbPSF point spread function modeling package, and the Space Telescope Image Product Simulator (STIPS).   Comprehensive setup documentation for local installation as well as tutorials for Pandeia and WebbPSF are provided here.  STIPS is available at https://github.com/spacetelescope/STScI-STIPS.  High level overviews of the functionality of the tools are available on [STScI's WFIRST website](http://www.stsci.edu/scientific-community/wide-field-infrared-survey-telescope/science-planning-toolbox).
 
 Would you like to [launch the tools in a temporary environment in the cloud](#Play-with-the-tools-in-a-temporary-environment-in-the-cloud) or [install the simulation tools locally](#install-the-simulation-tools-locally)?
 
@@ -12,12 +12,12 @@ To cite our tools, we ask that you reference [Pontoppidan et al. 2016, "Pandeia:
 
 The tutorials are stored as Jupyter Notebooks--documents which interleave code, figures, and prose explanations--and can be run locally once you have followed the setup instructions below. They can also be viewed in a browser.
 
-  * [WebbPSF-WFIRST Tutorial](https://github.com/spacetelescope/wfirst-tools/blob/master/notebooks/WebbPSF-WFIRST_Tutorial.ipynb) — Simulate a PSF for the WFIRST Wide-Field Instrument by selecting a detector position. Evaluate PSF differences between two detector positions. Shows both the WebbPSF notebook GUI and a brief example of performing calculations with the API.
+  * [WebbPSF-WFIRST Tutorial](https://github.com/spacetelescope/wfirst-tools/blob/master/notebooks/WebbPSF-WFIRST_Tutorial.ipynb) — Simulate a PSF for the Roman Wide-Field Instrument by selecting a detector position. Evaluate PSF differences between two detector positions. Shows both the WebbPSF notebook GUI and a brief example of performing calculations with the API.
   * [Pandeia-WFIRST Tutorial](https://github.com/spacetelescope/wfirst-tools/blob/master/notebooks/Pandeia-WFIRST.ipynb) — Calculate exposure times and simulate detector "postage stamps" for scenes made up of point sources and extended sources.
 
 ## Play with the tools in a temporary environment in the cloud
 
-We have automated the setup of a temporary evaluation environment for community users to evaluate the WFIRST Simulation Tools from STScI. This depends on a free third-party service called Binder, currently available in beta (without guarantees of uptime).
+We have automated the setup of a temporary evaluation environment for community users to evaluate the Roman Simulation Tools from STScI. This depends on a free third-party service called Binder, currently available in beta (without guarantees of uptime).
 
 To launch in Binder *(beta)*, follow this URL: https://mybinder.org/v2/gh/spacetelescope/wfirst-tools.git/stable (**Note:** If you see an error involving redirects in Safari, try Chrome or Firefox. This should be fixed soon by the Binder project.)
 
@@ -105,22 +105,22 @@ Commands for you to execute will be prefixed with a `$`. (You only need to type 
 
 ### Installing Astroconda
 
-If you have already installed Astroconda, skip ahead to "Creating a WFIRST Tools environment".
+If you have already installed Astroconda, skip ahead to "Creating a Roman Tools environment".
 
 The [Getting Started](http://astroconda.readthedocs.io/en/latest/getting_started.html) instructions for Astroconda cover setting up the conda package manager and certain environment variables. Enable the Astroconda channel with the command `conda config --add channels http://ssb.stsci.edu/astroconda` (as explained in the [Selecting a Software Stack](http://astroconda.readthedocs.io/en/latest/installation.html#configure-conda-to-use-the-astroconda-channel) document).
 
-The WFIRST Simulation Tools suite includes Pandeia, an exposure time and signal-to-noise calculator. To create a Python environment for WFIRST Simulation Tools, use the following command:
+The Roman Simulation Tools suite includes the Pandeia engine, an exposure time and signal-to-noise calculator. To create a Python environment for Roman Simulation Tools, use the following command:
 
 ```
 $ conda create -n wfirst-tools --yes python=3.7 astropy \
-                                    pysynphot photutils \
+                                    synphot stsynphot photutils \
                                     future pyyaml pandas \
                                     webbpsf==0.9 webbpsf-data==0.9
 
 
 ```
 
-This will create an environment called `wfirst-tools` containing the essential packages for WFIRST simulations. To use it, you must activate it every time you open a new terminal window. Go ahead and do that now:
+This will create an environment called `wfirst-tools` containing the essential packages for Roman simulations. To use it, you must activate it every time you open a new terminal window. Go ahead and do that now:
 
 ```
 $ source activate wfirst-tools
@@ -132,7 +132,7 @@ Next, create a new directory somewhere with plenty of space to hold the referenc
 
 ### Installing synthetic photometry reference information
 
-To obtain the [reference data](http://pysynphot.readthedocs.io/en/latest/#installation-and-setup) used for synthetic photometry, you will need to retrieve them via FTP. The `curl` command line tool can be used as follows to retrieve the archives:
+To obtain the [reference data](https://stsynphot.readthedocs.io/en/latest/#installation-and-setup) used for synthetic photometry, you will need to retrieve them via FTP. The `curl` command line tool can be used as follows to retrieve the archives:
 
 ```
 (wfirst-tools) $ curl -OL ftp://ftp.stsci.edu/cdbs/tarfiles/synphot1.tar.gz    # 85 MB
@@ -150,64 +150,64 @@ This retrieves interstellar extinction curves, several spectral atlases, and a g
 
 This will create a tree of files rooted at `grp/hst/cdbs/` in the current directory.
 
-(Instructions for installing the full set of PySynphot reference data, including things like HST instrument throughput reference files, can be found [in the PySynphot documentation](http://pysynphot.readthedocs.io/en/latest/index.html#installation-and-setup).)
+(Instructions for installing the full set of Synphot reference data, including things like HST instrument throughput reference files, can be found [in the PySynphot documentation](http://pysynphot.readthedocs.io/en/latest/index.html#installation-and-setup).)
 
-### Installing the Pandeia engine
+### Installing the Pandeia Engine
 
-Pandeia is available through PyPI (the Python Package Index), rather than Astroconda. Fortunately, we can install it into our `wfirst-tools` environment with the following command:
-
-```
-(wfirst-tools) $ pip install pandeia.engine==1.5.1
-```
-
-Note that the `==1.5.1` on the package name explicitly requests version 1.5.1, which is the version that is compatible with the bundled reference data.
-
-Pandeia also depends on a collection of reference data to define the characteristics of the WFIRST instruments. Download it (54 MB) as follows and extract:
+The Pandeia Engine is available through PyPI (the Python Package Index), rather than Astroconda. Fortunately, we can install it into our `wfirst-tools` environment with the following command:
 
 ```
-(wfirst-tools) $ curl -OL https://stsci.box.com/shared/static/ve02bw7h6qzmxtu8rpxewkl3m5jduacq.gz
-(wfirst-tools) $ tar xvzf ./ve02bw7h6qzmxtu8rpxewkl3m5jduacq.gz
+(wfirst-tools) $ pip install pandeia.engine==1.5.2
 ```
 
-This creates a folder called `pandeia_data-1.5.1_wfirst` in the current directory.
+Note that the `==1.5.2` on the package name explicitly requests version 1.5.2, which is the version that is compatible with the bundled reference data.
+
+Pandeia also depends on a collection of reference data to define the characteristics of the WFIRST instruments. Download it (40 MB) as follows and extract:
+
+```
+(wfirst-tools) $ curl -OL https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz
+(wfirst-tools) $ tar xvzf ./7voehzi5krrpml5wgyg8bo954ew7arh2.gz
+```
+
+This creates a folder called `pandeia_data-1.5.2_roman` in the current directory.
 
 ## Running the simulation tools locally
 
-WebbPSF, Pandeia, and pysynphot all depend on certain environment variables to determine the paths to reference data.
+WebbPSF, Pandeia, and synphot all depend on certain environment variables to determine the paths to reference data.
 
-You may wish to save these variables in your `~/.bash_profile` file, or [a new conda/activate.d/ script](https://conda.io/docs/using/envs.html#saved-environment-variables) so they are always set when you go to run the WFIRST simulation tools.
+You may wish to save these variables in your `~/.bash_profile` file, or [a new conda/activate.d/ script](https://conda.io/docs/using/envs.html#saved-environment-variables) so they are always set when you go to run the Roman simulation tools.
 
 ### Configuring environment variables
 
 Where you see `$(pwd)` in the following commands, substitute in the directory where you have chosen to store the reference data (e.g. `echo "$(pwd)"` becomes `echo "/path/to/reference/file/space"`).
 
-Configure the PySynphot CDBS path:
+Configure the Synphot CDBS path:
 
 ```
 (wfirst-tools) $ export PYSYN_CDBS="$(pwd)/grp/hst/cdbs"
 ```
 
-To test that pysynphot can find its reference files, use the following command:
+To test that synphot can find its reference files, use the following command:
 
 ```
-(wfirst-tools) $ python -c "import warnings; warnings.simplefilter('ignore'); import pysynphot; print pysynphot.Icat('phoenix', 5750, 0.0, 4.5).name"
+(wfirst-tools) $ python -c "import warnings; warnings.simplefilter('ignore'); import stsynphot; print(stsynphot.catalog.grid_to_spec('phoenix', 5750, 0.0, 4.5))"
 ```
 
-If you see "phoenix(Teff=5750,z=0,logG=4.5)" appear in your terminal, pysynphot and its reference data files have been installed correctly.
+If you see output for a SourceSpectrum detailing the Model, Inputs, Outputs, and Components, synphot, stsynphot, and their reference data files have been installed correctly.
 
 Next, configure the Pandeia path:
 
 ```
-(wfirst-tools) $ export pandeia_refdata="$(pwd)/pandeia_data-1.5.1_wfirst"
+(wfirst-tools) $ export pandeia_refdata="$(pwd)/pandeia_data-1.5.2_roman"
 ```
 
 To test that Pandeia can find its reference files, use the following command:
 
 ```
-(wfirst-tools) $ python -c 'from pandeia.engine.wfirst import WFIRSTImager; WFIRSTImager(mode="imaging")'
+(wfirst-tools) $ python -c 'import pandeia.engine; pandeia.engine.pandeia_version()'
 ```
 
-If you do not see any errors, Pandeia was able to instantiate a WFIRST WFI model successfully.
+If your data is set up correctly, it will output the version numbers for the Engine and RefData.
 
 ### Viewing and running these example notebooks
 
@@ -221,7 +221,7 @@ This will create a new folder called `wfirst-tools` containing this README and a
 
 ## Resources
 
-Pandeia users are encouraged to address questions, suggestions, and bug reports to help@stsci.edu with "Pandeia-WFIRST question" in the subject line. The message will be directed to the appropriate members of the Pandeia-WFIRST team at STScI.  For issues with WebbPSF, we prefer that you report your issues in the GitHub issue tracker for the speediest response: https://github.com/spacetelescope/webbpsf/issues (choose the green "New Issue" button after logging in).
+Pandeia users are encouraged to address questions, suggestions, and bug reports to help@stsci.edu with "Pandeia-Roman question" in the subject line. The message will be directed to the appropriate members of the Pandeia-Roman team at STScI.  For issues with WebbPSF, we prefer that you report your issues in the GitHub issue tracker for the speediest response: https://github.com/spacetelescope/webbpsf/issues (choose the green "New Issue" button after logging in).
 
 
   * [WebbPSF documentation](https://pythonhosted.org/webbpsf/)

--- a/notebooks/Pandeia-WFIRST.ipynb
+++ b/notebooks/Pandeia-WFIRST.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "To set up default observations for one of these three modes, run one of the three following cells.\n",
     "\n",
-    "### WFIRST Imager"
+    "### WFIRST Imaging"
    ]
   },
   {
@@ -83,14 +83,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calc = build_default_calc('wfirst','wfirstimager','imager')"
+    "calc = build_default_calc('wfirst','wfirstimager','imaging')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### WFIRST Grism"
+    "### WFIRST Spectroscopy"
    ]
   },
   {
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calc = build_default_calc('wfirst','wfirstimager','grism')"
+    "calc = build_default_calc('wfirst','wfirstimager','spectroscopy')"
    ]
   },
   {
@@ -388,9 +388,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### WFIRST Imager\n",
+    "### WFIRST Imaging\n",
     "\n",
-    "For the WFIRST Imager:\n",
+    "For WFIRST Imaging:\n",
     "\n",
     "- Filters\n",
     "   - f062 (R-band 0.62 microns)\n",
@@ -405,7 +405,7 @@
     "\n",
     "The detector can be configured to give multiple exposures in multiple groups and integrations, and set the readmode. We are using the available JWST NIRCam configurations as stand-ins for the WFIRST detector, as the WFIRST WFI detectors are expected to be very similar to the NIRCam detectors. \n",
     "\n",
-    "For the WFIRST imager, there are a number of readout patterns:\n",
+    "For WFIRST Imaging, there are a number of readout patterns (though the final telescope will only support a limited subset of these):\n",
     "\n",
     "- Readout Patterns:\n",
     "   - 'rapid'\n",
@@ -446,7 +446,7 @@
     "calc['configuration']['detector']['ngroup'] = 6 # groups per integration\n",
     "calc['configuration']['detector']['nint'] = 1 # integrations per exposure\n",
     "calc['configuration']['detector']['nexp'] = 1 # exposures\n",
-    "calc['configuration']['detector']['readout_pattern'] = \"medium8\"\n",
+    "calc['configuration']['detector']['readmode'] = \"medium8\"\n",
     "calc['configuration']['detector']['subarray'] = \"1024x1024\""
    ]
   },
@@ -454,9 +454,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### WFIRST Grism\n",
+    "### WFIRST Spectroscopy\n",
     "\n",
-    "For the WFIRST Grism, there is much less to configure. There are no filters, and two dispersers: The grism and the prism.\n",
+    "For WFIRST Spectroscopy, there is much less to configure. There are no filters, and two dispersers: The grism (g150) and the prism (p120).\n",
     "\n",
     "* Dispersers:\n",
     "  * g150 (default)\n",
@@ -464,7 +464,7 @@
     "  \n",
     "The readout pattern and subarray options are the same as the WFIRST Imager imaging mode.\n",
     "\n",
-    "To approximate the current design for the High Latitude Spectroscopic Survey, we recommend using subarray '1024x1024', readmode 'medium8', and Ngroups = 13"
+    "To approximate the current design for the High Latitude Spectroscopic Survey, we recommend using subarray '1024x1024', readout pattern 'medium8', and Ngroups = 13"
    ]
   },
   {
@@ -474,12 +474,12 @@
    "outputs": [],
    "source": [
     "calc['configuration']['instrument']['filter'] = None\n",
-    "calc['configuration']['instrument']['aperture'] = \"grism\"\n",
+    "calc['configuration']['instrument']['aperture'] = \"any\"\n",
     "calc['configuration']['instrument']['disperser'] = \"g150\"\n",
     "calc['configuration']['detector']['ngroup'] = 13 # groups per integration\n",
     "calc['configuration']['detector']['nint'] = 1 # integrations per exposure\n",
     "calc['configuration']['detector']['nexp'] = 1 # exposures\n",
-    "calc['configuration']['detector']['readout_pattern'] = \"medium8\"\n",
+    "calc['configuration']['detector']['readmode'] = \"medium8\"\n",
     "calc['configuration']['detector']['subarray'] = \"1024x1024\""
    ]
   },
@@ -507,7 +507,7 @@
     "calc['configuration']['detector']['ngroup'] = 10 # groups per integration\n",
     "calc['configuration']['detector']['nint'] = 1 # integrations per exposures\n",
     "calc['configuration']['detector']['nexp'] = 1 # exposures\n",
-    "calc['configuration']['detector']['readout_pattern'] = \"nrs\"\n",
+    "calc['configuration']['detector']['readmode'] = \"nrs\"\n",
     "calc['configuration']['detector']['subarray'] = \"full\""
    ]
   },
@@ -517,8 +517,8 @@
    "source": [
     "# We can now set up the observing strategy. \n",
     "\n",
-    "### WFIRST Imager\n",
-    "For the WFIRST imager, there are a few options to set up the location, extraction aperture, and background extraction annulus through which the flux and SNR will be calculated. The only strategy available for the imager is 'imagingapphot' (Imaging Aperture Photometry) and is already set by default."
+    "### WFIRST Imaging\n",
+    "For WFIRST imaging, there are a few options to set up the location, extraction aperture, and background extraction annulus through which the flux and SNR will be calculated. The only strategy available for the imager is 'imagingapphot' (Imaging Aperture Photometry) which is already set by default."
    ]
   },
   {
@@ -536,9 +536,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### WFIRST Grism\n",
+    "### WFIRST Spectroscopy\n",
     "\n",
-    "For the WFIRST grism, the only strategy available is 'specapphot' (Aperture Spectral Extraction) and again does not need to be set. \n",
+    "For WFIRST spectroscopy, the only strategy available is 'specapphot' (Aperture Spectral Extraction) and again will already be set. \n",
     "\n",
     "The rest of the options are quite similar to the imager options, with the addition of a reference wavelength at which you want the flux and SNR to be calculated for the numerical results. If it is set to None, Pandeia will choose the central wavelength of the disperser."
    ]
@@ -566,7 +566,7 @@
     " - 'ifunodinscene': IFU Nod (in-scene) - the default. The same as the above, but with an dither smaller (generally <5 arcsec) than the FOV size.\n",
     " - 'ifunodoffscene': IFU Nod (off-scene). The same as the above, but the dither is larger (generally >10 arcsec) than the FOV size.\n",
     "    \n",
-    "Note that Pandeia doesn't currently shift when it adds the dithers; this is a known limitation."
+    "Note that Pandeia doesn't currently shift when it adds the dithers for the 2D displayed imaging, but all calculations are done with correctly-extracted data from the individual dithers."
    ]
   },
   {
@@ -653,8 +653,10 @@
     "        basename += \" pixel^2\"\n",
     "    elif \"wavelength\" in x:\n",
     "        basename += \" microns\"\n",
-    "    elif \"background\" in x or \"extracted\" in x:\n",
+    "    elif ((\"extracted\" in x) or (\"sky\" in x)) or (\"total\" in x):\n",
     "        basename += \" e-/sec\"\n",
+    "    elif \"background\" in x:\n",
+    "        basename += \" MJy/sr\"\n",
     "    else:\n",
     "        pass\n",
     "    print(basename.format(x,results[\"scalar\"][x]))\n",
@@ -775,7 +777,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -789,7 +791,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/Pandeia-WFIRST_GUI.ipynb
+++ b/notebooks/Pandeia-WFIRST_GUI.ipynb
@@ -32,9 +32,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:pan9.2_c_3.6]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-pan9.2_c_3.6-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -46,7 +46,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR contains new notebooks and a revised Dockerfile and README for Pandeia Engine v1.5.2 (to be released 2020.08.31).

One specific question: Does WebbPSF 0.9.0 still rely on pysyphot? If so, it needs to be added back to the conda installation commands.