### PR TITLE
Update for 1.6.2 and readout_pattern

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN wget -qO- https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-a
 ENV PYSYN_CDBS /opt/grp/redcat/trds
 
 # Extract Pandeia reference data
-RUN wget -qO- https://stsci.box.com/shared/static/ksg2b7whqgzmvuqoln6zj9u2usomsgfu.gz | tar xvz
-ENV pandeia_refdata /opt/pandeia_data-1.6_roman
+RUN wget -qO- https://stsci.box.com/shared/static/h99co8sxn2exmcbydnu28qiix3eqtogd.gz | tar xvz
+ENV pandeia_refdata /opt/pandeia_data-1.6.2_roman
 
 # Extract WebbPSF reference data
 # (note: version number env vars are declared close to where they are used
@@ -55,7 +55,7 @@ RUN conda install --quiet --yes $EXTRA_PACKAGES && \
 RUN pip install ipywidgets==7.0.0
 
 # Install Pandeia
-ENV PANDEIA_VERSION 1.6
+ENV PANDEIA_VERSION 1.6.2
 RUN pip install --no-cache-dir pandeia.engine==$PANDEIA_VERSION
 
 # Install WebbPSF

--- a/README.md
+++ b/README.md
@@ -159,19 +159,19 @@ This will create a tree of files rooted at `grp/redcat/trds/` in the current dir
 The Pandeia Engine is available through PyPI (the Python Package Index), rather than Astroconda. Fortunately, we can install it into our `roman_tools` environment with the following command:
 
 ```
-(roman_tools) $ pip install pandeia.engine==1.6
+(roman_tools) $ pip install pandeia.engine==1.6.2
 ```
 
-Note that the `==1.6` on the package name explicitly requests version 1.6, which is the version that is compatible with the bundled reference data.
+Note that the `==1.6.2` on the package name explicitly requests version 1.6.2, which is the version that is compatible with the bundled reference data.
 
 Pandeia also depends on a collection of reference data to define the characteristics of the Roman instruments. Download it (40 MB) as follows and extract:
 
 ```
-(roman_tools) $ curl -OL https://stsci.box.com/shared/static/ksg2b7whqgzmvuqoln6zj9u2usomsgfu.gz
-(roman_tools) $ tar xvzf ./ksg2b7whqgzmvuqoln6zj9u2usomsgfu.gz
+(roman_tools) $ curl -OL https://stsci.box.com/shared/static/h99co8sxn2exmcbydnu28qiix3eqtogd.gz
+(roman_tools) $ tar xvzf ./h99co8sxn2exmcbydnu28qiix3eqtogd.gz
 ```
 
-This creates a folder called `pandeia_data-1.6_roman` in the current directory.
+This creates a folder called `pandeia_data-1.6.2_roman` in the current directory.
 
 ## Running the simulation tools locally
 
@@ -200,7 +200,7 @@ If you see output for a SourceSpectrum detailing the Model, Inputs, Outputs, and
 Next, configure the Pandeia path:
 
 ```
-(roman_tools) $ export pandeia_refdata="$(pwd)/pandeia_data-1.6_roman"
+(roman_tools) $ export pandeia_refdata="$(pwd)/pandeia_data-1.6.2_roman"
 ```
 
 To test that Pandeia can find its reference files, use the following command:

--- a/notebooks/Pandeia-Roman.ipynb
+++ b/notebooks/Pandeia-Roman.ipynb
@@ -414,8 +414,8 @@
     "   \n",
     "To best approximate readouts as currently envisioned for Roman, we suggest using the following:\n",
     " - Subarray '1024x1024', which has a similar frame time (2.7s) as that expected for the Roman WFI.\n",
-    " - _To approximate the current design for the High Latitude Imaging Survey:_ readmode 'medium8' with Ngroups = 6\n",
-    " - _To approximate the current design for the Exoplanet Microlensing Survey:_ readmode 'shallow2' with Ngroups = 4"
+    " - _To approximate the current design for the High Latitude Imaging Survey:_ readout_pattern 'medium8' with Ngroups = 6\n",
+    " - _To approximate the current design for the Exoplanet Microlensing Survey:_ readout_pattern 'shallow2' with Ngroups = 4"
    ]
   },
   {
@@ -430,7 +430,7 @@
     "calc['configuration']['detector']['ngroup'] = 6 # groups per integration\n",
     "calc['configuration']['detector']['nint'] = 1 # integrations per exposure\n",
     "calc['configuration']['detector']['nexp'] = 1 # exposures\n",
-    "calc['configuration']['detector']['readmode'] = \"medium8\"\n",
+    "calc['configuration']['detector']['readout_pattern'] = \"medium8\"\n",
     "calc['configuration']['detector']['subarray'] = \"1024x1024\""
    ]
   },
@@ -463,7 +463,7 @@
     "calc['configuration']['detector']['ngroup'] = 13 # groups per integration\n",
     "calc['configuration']['detector']['nint'] = 1 # integrations per exposure\n",
     "calc['configuration']['detector']['nexp'] = 1 # exposures\n",
-    "calc['configuration']['detector']['readmode'] = \"medium8\"\n",
+    "calc['configuration']['detector']['readout_pattern'] = \"medium8\"\n",
     "calc['configuration']['detector']['subarray'] = \"1024x1024\""
    ]
   },
@@ -679,7 +679,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -693,7 +693,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I'm not sure who should review this, but this file updates the roman_tools repo to correct a very old bug in the Jupyter notebook that used the wrong name for the readout_pattern. It also updates the Dockerfile and README to Pandeia v1.6.2

Fixes JETC-2047